### PR TITLE
Avoid confusion about milliseconds in timestamps

### DIFF
--- a/docs/rest.rst
+++ b/docs/rest.rst
@@ -543,7 +543,7 @@ Advanced usage
    :<json string class: Default 'standard'. The message class to use for this request. If specified it must be the same for all messages in the request.
    :<json string message: The content of the SMS, *always* specified in UTF-8 encoding, which we will transcode depending on the "encoding" field. The default is the usual :term:`GSM 03.38` encoding. Required unless payload is specified.
    :<json string sender: Up to 11 alphanumeric characters, or 15 digits, that will be shown as the sender of the SMS.
-   :<json integer sendtime: Unix timestamp to schedule message sending at certain time.
+   :<json integer sendtime: Unix timestamp (seconds since epoch) to schedule message sending at certain time.
    :<json array tags: A list of string tags, which will be replaced with the tag values for each recipient.
    :<json string userref: A transparent string reference, you may set to keep track of the message in your own systems. Returned to you when you receive a `Delivery Status Notification`_.
    :<json string priority: Default 'NORMAL'. One of 'BULK', 'NORMAL', 'URGENT' and 'VERY_URGENT'. Urgent and Very Urgent normally require the use of premium message class.


### PR DESCRIPTION
Some think that a unix timestamp is in milliseconds and not seconds,
avoid confusion by stating seconds.